### PR TITLE
Stack 2 compatibility

### DIFF
--- a/blaze-colonnade/blaze-colonnade.cabal
+++ b/blaze-colonnade/blaze-colonnade.cabal
@@ -32,6 +32,7 @@ test-suite test
       base >= 4.7 && <= 5
     , colonnade
     , doctest
+    , profunctors
   default-language: Haskell2010
 
 source-repository head

--- a/siphon/test/Doctest.hs
+++ b/siphon/test/Doctest.hs
@@ -2,6 +2,7 @@ import Test.DocTest
 
 main :: IO ()
 main = doctest
-  [ "src/Siphon.hs"
+  [ "-isrc"
+  , "src/Siphon.hs"
   ]
 


### PR DESCRIPTION
Stack 2 is more explicit about packages available in tests as a measure against ambiguous module names (Stackage is getting built with Stack so this is a noticeable problem now).
I've tried cabal's v2 commands and they seem to work without this fixes though `cabal new-test` fails without `cabal new-build` before that which is a bit odd.
Without a new release we'll be required to put `blaze-colonnade` into `expected-test-failures` section of Stackage.